### PR TITLE
Add sphinx_reredirects extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,9 @@ sphinx-jsonschema_
 sphinx-gitstamp_
    Makes the git timestamp for each page available to HTML templates.
 
+sphinx-reredirects_
+   Handles redirects for moved pages. Based on the its configuration, the extension generates HTML pages with meta refresh redirects to the new page location to prevent 404 errors if you rename or move your documents.
+
 .. _blockdiag: http://blockdiag.com/en/blockdiag/index.html
 .. _breathe: https://github.com/michaeljones/breathe
 .. _javasphinx: https://github.com/bronto/javasphinx
@@ -188,6 +191,7 @@ sphinx-gitstamp_
 .. _nbsphinx: https://nbsphinx.readthedocs.io/en/latest/
 .. _sphinx-jsonschema: https://github.com/lnoor/sphinx-jsonschema
 .. _jsonschema: http://json-schema.org
+.. _sphinx-reredirects: https://gitlab.com/documatt/sphinx-reredirects
 
 Internationalizations
 ---------------------


### PR DESCRIPTION
It is the extension for managing redirects with client-side HTML files containing meta refresh tags. Many static file hosting doesn't support redirects, and to prevent 404 if page is moved or renamed, the client-side redirect are the only option. The extension supports wildcards and has configurable HTML file template.

DISCLAIMER: I'm author of the extension.